### PR TITLE
Fix failing CI workflows + guard delisted data integrity + bump actions to Node 24

### DIFF
--- a/.github/workflows/database_update.yml
+++ b/.github/workflows/database_update.yml
@@ -2,6 +2,8 @@ name: Database Update
 
 on:
   push:
+    branches:
+      - 'main'
   schedule:
     - cron: '0 12 * * SUN'
 
@@ -10,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: pull changes
         run: git pull https://${{secrets.PAT}}@github.com/JerBouma/FinanceDatabase.git main
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - run: pip install "pandas[excel]" financedatabase
       - name: Add New Tickers and Update Old Ones
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@v1.8
         with:
           script: |
             import glob
@@ -285,16 +287,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: pull changes
         run: git pull https://${{secrets.PAT}}@github.com/JerBouma/FinanceDatabase.git main
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - run: pip install "pandas[excel]" financedatabase
       - name: Update Compressions
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@v1.8
         with:
           script: |
             import glob
@@ -345,16 +347,16 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: checkout repo content
-          uses: actions/checkout@v3
+          uses: actions/checkout@v6
         - name: pull changes
           run: git pull https://${{secrets.PAT}}@github.com/JerBouma/FinanceDatabase.git main
         - name: setup python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v6
           with:
             python-version: '3.10'
         - run: pip install "pandas[excel]" financedatabase
         - name: Update categories
-          uses: jannekem/run-python-script-action@v1
+          uses: jannekem/run-python-script-action@v1.8
           with:
             script: |
               import glob
@@ -455,16 +457,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: pull changes
         run: git pull https://${{secrets.PAT}}@github.com/JerBouma/FinanceDatabase.git main
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
       - run: pip install pandas
       - name: Refresh the statistics tables in README.md
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@v1.8
         with:
           script: |
             import glob
@@ -569,14 +571,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo content
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - run: pip install "pandas[excel]" financedatabase
       - name: Check GICS Categorisation
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@v1.8
         with:
           script: |
             import glob

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,15 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
       - name: Setup Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           architecture: x64
@@ -39,7 +39,7 @@ jobs:
     name: Markdown Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         name: Check out the code
       - name: Lint Code Base
         uses: docker://avtodev/markdown-lint:v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,15 +13,15 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Install uv
-              uses: astral-sh/setup-uv@v5
+              uses: astral-sh/setup-uv@v7
               with:
                 enable-cache: true
 
             - name: Set up Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@v6
               with:
                 python-version: '3.10'
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pandas as pd
+
 import financedatabase as fd
 
 
@@ -76,3 +80,21 @@ def test_no_isin_collisions_across_asset_classes() -> None:
         f"({len(shared)} total): {sorted(shared)[:5]}"
         f"{' ...' if len(shared) > 5 else ''}"
     )
+
+
+def test_delisted_is_strictly_boolean() -> None:
+    """`delisted` must be a real bool column: no NaN, no stray types.
+
+    `Equities.select()` filters with `~equities["delisted"]`, which only
+    negates correctly on a bool dtype, so anything else is dirty data.
+    """
+    files = sorted(Path("database/equities").glob("*.csv"))
+    assert files, "no equities CSVs found under database/equities/"
+    delisted = pd.concat([pd.read_csv(f, index_col=0)["delisted"] for f in files])
+    if delisted.dtype != bool:
+        offenders = delisted[~delisted.isin([True, False])]
+        raise AssertionError(
+            f"'delisted' is not bool dtype (got {delisted.dtype}); "
+            f"{len(offenders)} invalid/NaN value(s), e.g. "
+            f"{offenders.index[:5].tolist()}"
+        )


### PR DESCRIPTION
## What

- **`database_update.yml`**: restore the `push` branch filter to `main`. It was running on every branch, and the commit step failed on `git checkout main` (`pathspec 'main' did not match`) on non-main checkouts.
- **Node 24 bump** (all 3 workflows): `checkout@v6`, `setup-python@v6`, `setup-uv@v7`, `run-python-script-action@v1.8` — clears the Node 20 deprecation.
- **`tests/test_invariants.py`**: invariant asserting equities `delisted` is strictly `bool`, so a NaN (which breaks `~equities["delisted"]`) fails CI before merge.

## Note

Per review feedback, the library filter is left untouched — bad `delisted` data should fail loudly. The invariant catches it at the data layer instead. Related: #153.
